### PR TITLE
Add homepage

### DIFF
--- a/fraction_tree.gemspec
+++ b/fraction_tree.gemspec
@@ -7,12 +7,12 @@ Gem::Specification.new do |spec|
   spec.description = "A collection of Stern-Brocot based models and methods"
   spec.authors     = ["Jose Hales-Garcia"]
   spec.email       = "jose@halesgarcia.com"
+  spec.homepage    = "https://jolohaga.github.io/fraction-tree/"
   spec.files       = Dir.glob("lib/**/*")
   spec.add_runtime_dependency "continued_fractions", ["~> 1.8"]
   spec.add_development_dependency "rspec", ["~> 3.2"]
   spec.add_development_dependency "byebug", ["~> 11.1"]
   spec.add_development_dependency "yard", ["~> 0.9"]
-  spec.homepage    = "https://rubygems.org/gems/fraction-tree"
   spec.license     = "MIT"
   spec.date        = Date.today.to_s
 end


### PR DESCRIPTION
The homepage is the docs directory being served by Github pages.

This commit adds the homepage to the gemspec file, in preparation for RubyGems release.