### PR TITLE
Add Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of Stern-Brocot based models and methods.
 
 ## Installing
 
-    gem install fraction_tree
+    gem install fraction-tree
 
 ## Authors
 

--- a/fraction_tree.gemspec
+++ b/fraction_tree.gemspec
@@ -2,7 +2,7 @@ require "date"
 
 Gem::Specification.new do |spec|
   spec.name        = "fraction-tree"
-  spec.version     = "0.1.1"
+  spec.version     = "0.1.2"
   spec.summary     = "Fraction tree"
   spec.description = "A collection of Stern-Brocot based models and methods"
   spec.authors     = ["Jose Hales-Garcia"]
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/jolohaga/fraction-tree"
   }
   spec.files       = Dir.glob("lib/**/*")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.2.2")
   spec.add_runtime_dependency "continued_fractions", ["~> 1.8"]
   spec.add_development_dependency "rspec", ["~> 3.2"]
   spec.add_development_dependency "byebug", ["~> 11.1"]


### PR DESCRIPTION
RubyGems site shows a Ruby version requirment of 0.0.0.

This commit adds a Ruby version to the gemspec file, increasing the base requirement to 2.2.2.