### PR TITLE
Update rspec

### DIFF
--- a/fraction_tree.gemspec
+++ b/fraction_tree.gemspec
@@ -2,7 +2,7 @@ require "date"
 
 Gem::Specification.new do |spec|
   spec.name        = "fraction-tree"
-  spec.version     = "2.1.0"
+  spec.version     = "2.1.1"
   spec.summary     = "Fraction tree"
   spec.description = "A collection of Stern-Brocot based models and methods"
   spec.authors     = ["Jose Hales-Garcia"]
@@ -11,16 +11,17 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "source_code_uri" => "https://github.com/jolohaga/fraction-tree"
   }
+  spec.license     = "MIT"
+  spec.date        = Date.today.to_s
   spec.files       = Dir.glob("lib/**/*")
   spec.required_ruby_version = Gem::Requirement.new(">= 3.1")
   spec.required_rubygems_version = Gem::Requirement.new(">= 3.1")
+  spec.rubygems_version = "3.5.23"
   spec.add_runtime_dependency "matrix", ["~> 0.4"]
   spec.add_runtime_dependency "forwardable", ["~> 1.3"]
   spec.add_runtime_dependency "continued_fractions", ["~> 2.1"]
-  spec.add_development_dependency "rspec", ["~> 3.2"]
+  spec.add_development_dependency "rspec", ["~> 3"]
   spec.add_development_dependency "byebug", ["~> 11.1"]
   spec.add_development_dependency "yard", ["~> 0.9"]
   spec.add_development_dependency "rspec-benchmark", ["~> 0.6"]
-  spec.license     = "MIT"
-  spec.date        = Date.today.to_s
 end


### PR DESCRIPTION
Rspec being required was 9 years old.

This change updates the required rspec to the latest version.