### PR TITLE
Add #nearest_common_ancestor_with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .byebug_history
 .yardoc
 .rspec
+.claude
 tmp
 notes
 .Gemfile

--- a/fraction_tree.gemspec
+++ b/fraction_tree.gemspec
@@ -2,7 +2,7 @@ require "date"
 
 Gem::Specification.new do |spec|
   spec.name        = "fraction-tree"
-  spec.version     = "2.1.3"
+  spec.version     = "2.2.0"
   spec.summary     = "Fraction tree"
   spec.description = "A collection of Stern-Brocot based models and methods"
   spec.authors     = ["Jose Hales-Garcia"]

--- a/lib/fraction_tree/node.rb
+++ b/lib/fraction_tree/node.rb
@@ -159,6 +159,18 @@ class FractionTree
       path & tree.node(num).path
     end
 
+    # @return [FractionTree::Node] the nearest common ancestor of self and the given number
+    # @example
+    #   FractionTree.node(4/3r).nearest_common_ancestor_with(7/4r)
+    #   => (3/2)
+    #
+    # @param num [Numeric] other number sharing descendants with self
+    #
+    def nearest_common_ancestor_with(num)
+      common_ancestors_with(num).last
+    end
+    alias :nca_with :nearest_common_ancestor_with
+
     # @return [Array] of fraction tree nodes, descending from parents of number
     # @example
     #   FractionTree.node(5/4r).descendancy_from(depth: 3)

--- a/spec/fraction_tree/node_spec.rb
+++ b/spec/fraction_tree/node_spec.rb
@@ -174,6 +174,15 @@ RSpec.describe FractionTree::Node do
     end
   end
 
+  describe "#nearest_common_ancestor_with" do
+    let(:number1) { 7/6r }
+    let(:number2) { 15/13r }
+    let(:expected_node) { described_class.new(7/6r) }
+    it "returns the last node in common between the paths to the two numbers" do
+      expect(described_class.new(number1).nearest_common_ancestor_with(number2)).to eq expected_node
+    end
+  end
+
   describe "#descendancy_from" do
     let(:number) { 5/4r }
     let(:depth) { 3 }


### PR DESCRIPTION
Finding the nearest common ancestor between two nodes is useful in determining alternative close-enough approximations to real numbers.

This commit adds Node#nearest_common_ancestor_with to return self's NCA with the given argument.